### PR TITLE
Fix website url

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The frontend for SimplyTranslate engine, which you can use for translation for m
 
 ## Documentation and resources
 
-* Official app website: <https://simple-web.org/projects/simplytranslate.html>
+* Official app website: <https://simplytranslate.org>
 * Upstream app code repository: <https://codeberg.org/SimpleWeb/SimplyTranslate-Web>
 * YunoHost Store: <https://apps.yunohost.org/app/simplytranslate>
 * Report a bug: <https://github.com/YunoHost-Apps/simplytranslate_ynh/issues>

--- a/README_fr.md
+++ b/README_fr.md
@@ -30,7 +30,7 @@ L'interface du moteur SimplyTranslate, que vous pouvez utiliser pour la traducti
 
 ## Documentations et ressources
 
-* Site officiel de l’app : <https://simple-web.org/projects/simplytranslate.html>
+* Site officiel de l’app : <https://simplytranslate.org>
 * Dépôt de code officiel de l’app : <https://codeberg.org/SimpleWeb/SimplyTranslate-Web>
 * YunoHost Store: <https://apps.yunohost.org/app/simplytranslate>
 * Signaler un bug : <https://github.com/YunoHost-Apps/simplytranslate_ynh/issues>

--- a/manifest.toml
+++ b/manifest.toml
@@ -12,7 +12,7 @@ maintainers = ["the7thNightmare"]
 
 [upstream]
 license = "AGPL-3.0"
-website = "https://simple-web.org/projects/simplytranslate.html"
+website = "https://simplytranslate.org/"
 code = "https://codeberg.org/SimpleWeb/SimplyTranslate-Web"
 
 [integration]


### PR DESCRIPTION
## Problem

I just found that in the official YNH app catalog the website URL leads to a broken site. When you click the official website link on https://apps.yunohost.org/app/simplytranslate it leads to https://simple-web.org/projects/simplytranslate.html which is a dead link.

## Solution

I updated the website URL to the current URL: https://simplytranslate.org/

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
